### PR TITLE
Create additional dialect for thymeleaf

### DIFF
--- a/src/main/java/org/lastaflute/thymeleaf/ThymeleafHtmlRenderer.java
+++ b/src/main/java/org/lastaflute/thymeleaf/ThymeleafHtmlRenderer.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.dbflute.helper.message.ExceptionMessageBuilder;
 import org.lastaflute.di.helper.beans.PropertyDesc;
+import org.lastaflute.thymeleaf.wrapper.ActionMessagesWrapper;
 import org.lastaflute.web.LastaWebKey;
 import org.lastaflute.web.callback.ActionRuntime;
 import org.lastaflute.web.exception.RequestForwardFailureException;
@@ -88,7 +89,7 @@ public class ThymeleafHtmlRenderer implements HtmlRenderer {
     //                                         Export Errors
     //                                         -------------
     protected void exportErrorsToContext(RequestManager requestManager, WebContext context) {
-        context.setVariable("errors", extractActionErrors(requestManager));
+        context.setVariable("errors", new ActionMessagesWrapper(extractActionErrors(requestManager)));
     }
 
     protected ActionMessages extractActionErrors(RequestManager requestManager) {

--- a/src/main/java/org/lastaflute/thymeleaf/ThymeleafRenderingProvider.java
+++ b/src/main/java/org/lastaflute/thymeleaf/ThymeleafRenderingProvider.java
@@ -54,6 +54,9 @@ public class ThymeleafRenderingProvider implements HtmlRenderingProvider {
      */
     @Override
     public HtmlRenderer provideRenderer(ActionRuntime runtime, NextJourney journey) {
+        if (journey.getRoutingPath().endsWith(".jsp")) {
+            return DEFAULT_RENDERER;
+        }
         return new ThymeleafHtmlRenderer(getTemplateEngine());
     }
 

--- a/src/main/java/org/lastaflute/thymeleaf/ThymeleafRenderingProvider.java
+++ b/src/main/java/org/lastaflute/thymeleaf/ThymeleafRenderingProvider.java
@@ -15,13 +15,19 @@
  */
 package org.lastaflute.thymeleaf;
 
+import java.util.HashSet;
+
+import org.lastaflute.thymeleaf.processor.LastaThymeleafDialect;
 import org.lastaflute.web.callback.ActionRuntime;
 import org.lastaflute.web.ruts.NextJourney;
 import org.lastaflute.web.ruts.renderer.HtmlRenderer;
 import org.lastaflute.web.ruts.renderer.HtmlRenderingProvider;
 import org.lastaflute.web.util.LaServletContextUtil;
 import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.dialect.IDialect;
 import org.thymeleaf.messageresolver.StandardMessageResolver;
+import org.thymeleaf.processor.IProcessor;
+import org.thymeleaf.standard.StandardDialect;
 import org.thymeleaf.templateresolver.ServletContextTemplateResolver;
 import org.thymeleaf.templateresolver.TemplateResolver;
 
@@ -92,6 +98,16 @@ public class ThymeleafRenderingProvider implements HtmlRenderingProvider {
         final LastaThymeleafMessageResolver lastaThymeleafMessageResolver = new LastaThymeleafMessageResolver();
         lastaThymeleafMessageResolver.setOrder(10);
         engine.addMessageResolver(lastaThymeleafMessageResolver);
+
+        LastaThymeleafDialect dialect = new LastaThymeleafDialect(engine.getConfiguration());
+        engine.addDialect(dialect);
+
+        IDialect standard = engine.getDialectsByPrefix().get(StandardDialect.PREFIX);
+        if (standard instanceof StandardDialect) {
+            // Add to standard prefix access
+            ((StandardDialect)standard).setAdditionalProcessors(new HashSet<IProcessor>(dialect.getProcessors()));
+        }
+
     }
 
     protected TemplateResolver createTemplateResolver() {

--- a/src/main/java/org/lastaflute/thymeleaf/ThymeleafRenderingProvider.java
+++ b/src/main/java/org/lastaflute/thymeleaf/ThymeleafRenderingProvider.java
@@ -15,8 +15,6 @@
  */
 package org.lastaflute.thymeleaf;
 
-import java.util.HashSet;
-
 import org.lastaflute.thymeleaf.processor.LastaThymeleafDialect;
 import org.lastaflute.web.callback.ActionRuntime;
 import org.lastaflute.web.ruts.NextJourney;
@@ -24,10 +22,7 @@ import org.lastaflute.web.ruts.renderer.HtmlRenderer;
 import org.lastaflute.web.ruts.renderer.HtmlRenderingProvider;
 import org.lastaflute.web.util.LaServletContextUtil;
 import org.thymeleaf.TemplateEngine;
-import org.thymeleaf.dialect.IDialect;
 import org.thymeleaf.messageresolver.StandardMessageResolver;
-import org.thymeleaf.processor.IProcessor;
-import org.thymeleaf.standard.StandardDialect;
 import org.thymeleaf.templateresolver.ServletContextTemplateResolver;
 import org.thymeleaf.templateresolver.TemplateResolver;
 
@@ -101,12 +96,6 @@ public class ThymeleafRenderingProvider implements HtmlRenderingProvider {
 
         LastaThymeleafDialect dialect = new LastaThymeleafDialect(engine.getConfiguration());
         engine.addDialect(dialect);
-
-        IDialect standard = engine.getDialectsByPrefix().get(StandardDialect.PREFIX);
-        if (standard instanceof StandardDialect) {
-            // Add to standard prefix access
-            ((StandardDialect)standard).setAdditionalProcessors(new HashSet<IProcessor>(dialect.getProcessors()));
-        }
 
     }
 

--- a/src/main/java/org/lastaflute/thymeleaf/internal/package-info.java
+++ b/src/main/java/org/lastaflute/thymeleaf/internal/package-info.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * And the following license definition is for Thymeleaf.
+ * lasta-thymeleaf modified this source code and redistribute as same license.
+ * /- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ *
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2014, The THYMELEAF team (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Thymeleaf Team.
+ * For more information on the Thymeleaf, please see
+ * <http://www.thymeleaf.org>.
+ *
+ * - - - - - - - - - -/
+ */
+/**
+ * The source that was copied to extend from thymeleaf.
+ * @author modified by schatten (originated in Thymeleaf)
+ */
+package org.lastaflute.thymeleaf.internal;

--- a/src/main/java/org/lastaflute/thymeleaf/internal/processor/attr/AbstractIterationAttrProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/internal/processor/attr/AbstractIterationAttrProcessor.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * And the following license definition is for Thymeleaf.
+ * lasta-thymeleaf modified this source code and redistribute as same license.
+ * /- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ *
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2014, The THYMELEAF team (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Thymeleaf Team.
+ * For more information on the Thymeleaf, please see
+ * <http://www.thymeleaf.org>.
+ *
+ * - - - - - - - - - -/
+ */
+// from package org.thymeleaf.processor.attr;
+package org.lastaflute.thymeleaf.internal.processor.attr;
+
+import java.util.List;
+
+import org.thymeleaf.Arguments;
+import org.thymeleaf.dom.Element;
+import org.thymeleaf.dom.NestableNode;
+import org.thymeleaf.dom.Node;
+import org.thymeleaf.dom.Text;
+import org.thymeleaf.processor.IAttributeNameProcessorMatcher;
+import org.thymeleaf.processor.ProcessorResult;
+import org.thymeleaf.processor.attr.AbstractAttrProcessor;
+import org.thymeleaf.util.EvaluationUtil;
+import org.thymeleaf.util.Validate;
+
+/**
+ *
+ * @author Daniel Fern&aacute;ndez
+ *
+ * @since 1.0
+ *
+ * @author modified by schatten (originated in Thymeleaf)
+ * @see org.thymeleaf.processor.attr.AbstractIterationAttrProcessor Original
+ */
+public abstract class AbstractIterationAttrProcessor
+        extends AbstractAttrProcessor {
+
+
+    public static final String DEFAULT_STATUS_VAR_SUFFIX = "Stat";
+
+
+
+
+
+
+    protected AbstractIterationAttrProcessor(final String attributeName) {
+        super(attributeName);
+    }
+
+
+    protected AbstractIterationAttrProcessor(final IAttributeNameProcessorMatcher matcher) {
+        super(matcher);
+    }
+
+
+
+
+
+
+    @Override
+    public /*final*/ ProcessorResult processAttribute(final Arguments arguments, final Element element, final String attributeName) {
+
+
+        final NestableNode parentNode = element.getParent();
+
+        // Find out if there's some whitespace to duplicate so as to preserve the
+        // 'look' of the HTML code when completed
+        Node previousNode = null;
+        for (final Node child: parentNode.getChildren()) {
+            if (child == element) {
+                break;
+            }
+            previousNode = child;
+        }
+        boolean preserveWhitespace = false;
+        String whitespace = null;
+        if (previousNode != null && previousNode instanceof Text) {
+            final String content = ((Text)previousNode).getContent();
+            if (content.trim().length() == 0) {
+                preserveWhitespace = true;
+                whitespace = content;
+            }
+            else {
+                int i = content.length();
+                while (i > 0 && Character.isWhitespace(content.charAt(i - 1))) {
+                    i--;
+                }
+                if (i < content.length()) {
+                    preserveWhitespace = true;
+                    whitespace = content.substring(i);
+                }
+            }
+        }
+
+        final IterationSpec iterationSpec =
+            getIterationSpec(arguments, element, attributeName);
+
+
+//        final String iterVar = iterationSpec.getIterVarName();
+//        final String statusVar = iterationSpec.getStatusVarName();
+        final Object iteratedObject = iterationSpec.getIteratedObject();
+
+        final List<?> list = EvaluationUtil.evaluateAsIterable(iteratedObject);
+
+        final int size = list.size();
+        int index = 0;
+        for (final Object obj : list) {
+
+            // We choose not to clone processors because the host element
+            // has at least one processor that is not valid for the
+            // new cloned elements: the iteration processor.
+            final Element clonedElement = (Element) element.cloneNode(parentNode, false);
+            clonedElement.removeAttribute(attributeName);
+
+//            /*
+//             * Prepare local variables that will be available for each iteration item
+//             */
+//            clonedElement.setNodeLocalVariable(iterVar, obj);
+//            final StatusVar status =
+//                    new StatusVar(index, index + 1, size, obj);
+//            if (statusVar != null) {
+//                clonedElement.setNodeLocalVariable(statusVar, status);
+//            } else {
+//                clonedElement.setNodeLocalVariable(iterVar + DEFAULT_STATUS_VAR_SUFFIX, status);
+//            }
+            // Extract to Method.
+            prepareLocalVariablesForEachIterationItem(clonedElement, iterationSpec, size, index, obj);
+
+            // Add whitespace to preserve the look in the resulting HTML code
+            if (preserveWhitespace && index > 0) {
+                parentNode.insertBefore(element, new Text(whitespace));
+            }
+            parentNode.insertBefore(element, clonedElement);
+
+            processClonedHostIterationElement(arguments, clonedElement, attributeName);
+
+            index++;
+
+        }
+
+        parentNode.removeChild(element);
+
+        return ProcessorResult.OK;
+
+    }
+
+
+    protected void prepareLocalVariablesForEachIterationItem(final Element clonedElement, final IterationSpec iterationSpec,
+            final int size, int index, final Object obj) {
+        final String iterVar = iterationSpec.getIterVarName();
+        final String statusVar = iterationSpec.getStatusVarName();
+        /*
+         * Prepare local variables that will be available for each iteration item
+         */
+        clonedElement.setNodeLocalVariable(iterVar, obj);
+        final StatusVar status =
+                new StatusVar(index, index + 1, size, obj);
+        if (statusVar != null) {
+            clonedElement.setNodeLocalVariable(statusVar, status);
+        } else {
+            clonedElement.setNodeLocalVariable(iterVar + DEFAULT_STATUS_VAR_SUFFIX, status);
+        }
+    }
+
+
+
+
+
+
+
+    protected abstract IterationSpec getIterationSpec(
+            final Arguments arguments, final Element element, final String attributeName);
+
+
+
+    protected abstract void processClonedHostIterationElement(final Arguments arguments, final Element iteratedChild, final String attributeName);
+
+
+    /**
+     *
+     * @author Daniel Fern&aacute;ndez
+     *
+     * @since 1.0
+     *
+     */
+    public static class StatusVar {
+
+        private final int index;
+        private final int count;
+        private final int size;
+        private final Object current;
+
+        public StatusVar(final int index, final int count, final int size, final Object current) {
+            super();
+            this.index = index;
+            this.count = count;
+            this.size = size;
+            this.current = current;
+        }
+
+        public int getIndex() {
+            return this.index;
+        }
+
+        public int getCount() {
+            return this.count;
+        }
+
+        public int getSize() {
+            return this.size;
+        }
+
+        public Object getCurrent() {
+            return this.current;
+        }
+
+        public boolean isEven() {
+            return (this.index % 2 == 0);
+        }
+
+        public boolean isOdd() {
+            return !isEven();
+        }
+
+        public boolean isFirst() {
+            return (this.index == 0);
+        }
+
+        public boolean isLast() {
+            return (this.index == this.size - 1);
+        }
+
+        @Override
+        public String toString() {
+            return "{index = " + this.index + ", count = " + this.count +
+                    ", size = " + this.size + ", current = " + (this.current == null? "null" : this.current.toString()) + "}";
+        }
+
+    }
+
+
+
+    /**
+     *
+     * @author Daniel Fern&aacute;ndez
+     *
+     * @since 1.0
+     *
+     */
+    protected static class IterationSpec {
+
+        private final String iterVarName;
+        private final String statusVarName;
+        private final Object iteratedObject;
+
+        public IterationSpec(final String iterVarName,
+                final String statusVarName, final Object iteratedObject) {
+            super();
+            Validate.notEmpty(iterVarName, "Iteration var name cannot be null or empty");
+            this.iterVarName = iterVarName;
+            this.statusVarName = statusVarName;
+            this.iteratedObject = iteratedObject;
+        }
+
+        public String getIterVarName() {
+            return this.iterVarName;
+        }
+
+        public String getStatusVarName() {
+            return this.statusVarName;
+        }
+
+        public Object getIteratedObject() {
+            return this.iteratedObject;
+        }
+
+
+    }
+
+}

--- a/src/main/java/org/lastaflute/thymeleaf/processor/ExpressionCDefProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/ExpressionCDefProcessor.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.lastaflute.thymeleaf.processor;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Supplier;
+
+import org.dbflute.helper.message.ExceptionMessageBuilder;
+import org.dbflute.jdbc.Classification;
+import org.dbflute.jdbc.ClassificationMeta;
+import org.dbflute.optional.OptionalThing;
+import org.dbflute.optional.OptionalThingFunction;
+import org.lastaflute.core.direction.FwAssistantDirector;
+import org.lastaflute.core.util.ContainerUtil;
+import org.lastaflute.db.dbflute.classification.ListedClassificationProvider;
+import org.lastaflute.db.dbflute.exception.ProvidedClassificationNotFoundException;
+import org.thymeleaf.Arguments;
+import org.thymeleaf.context.IProcessingContext;
+import org.thymeleaf.exceptions.TemplateProcessingException;
+
+/**
+ * Utility methods for Classification objects.<br>
+ * <pre>
+ * Usage:
+ *     &lt;select&gt;
+ *       &lt;option th:each="def : ${#cdef.values('MemberStatus')}" th:value="${#cdef.code(def)}" th:text="${#cdef.alias(def)}"&gt;&lt;/option&gt;
+ *     &lt;/select&gt;
+ *
+ *   The result of processing this example will be as expected.
+ *     &lt;select&gt;
+ *       &lt;option value="FML"&gt;Formalized&lt;/option&gt;
+ *       &lt;option value="WDL"&gt;Withdrawal&lt;/option&gt;
+ *       &lt;option value="PRV"&gt;Provisional&lt;/option&gt;
+ *     &lt;/select&gt;
+ * </pre>
+ * @author schatten
+ */
+public class ExpressionCDefProcessor {
+
+    private final IProcessingContext processingContext;
+
+    public ExpressionCDefProcessor(IProcessingContext processingContext) {
+        this.processingContext = processingContext;
+    }
+
+    // ===================================================================================
+    //                                                                          Expression
+    //                                                                          ==========
+    /**
+     * Get Classification values.
+     * @param type classification-name
+     * @return classification values
+     */
+    public List<Classification> values(String type) {
+        try {
+            final ClassificationMeta meta = findClassificationMeta((String) type, new Supplier<Object>() {
+                public Object get() {
+                    return "${#cdef.values('" + type + "')}";
+                }
+            });
+            return meta.listAll();
+        } catch (Exception e) {
+            throw new TemplateProcessingException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Get Classification alias.
+     * @param def classification
+     * @return classification alias. (non classification is return null)
+     */
+    public String alias(Object def) {
+        if (def instanceof Classification) {
+            return findClassificationAlias((Classification) def);
+        }
+        return null;
+    }
+
+    /**
+     * Get Classification alias.
+     * @param type classification-name
+     * @param name classification element name
+     * @return classification alias
+     */
+    public String alias(String type, String name) {
+        try {
+            final ClassificationMeta meta = findClassificationMeta((String) type, new Supplier<Object>() {
+                public Object get() {
+                    return "${#cdef.alias('" + type + "', '" + name + "')}";
+                }
+            });
+            Classification def = meta.nameOf(name);
+            return def == null ? null : findClassificationAlias(def);
+        } catch (Exception e) {
+            throw new TemplateProcessingException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Get Classification code.
+     * @param def classification
+     * @return classification code. (non classification is return null)
+     */
+    public String code(Object def) {
+        if (def instanceof Classification) {
+            return ((Classification) def).code();
+        }
+        return null;
+    }
+
+    /**
+     * Get Classification code.
+     * @param type classification-name
+     * @param code classification element name
+     * @return classification code
+     */
+    public String code(String type, String code) {
+        try {
+            final ClassificationMeta meta = findClassificationMeta((String) type, new Supplier<Object>() {
+                public Object get() {
+                    return "${#cdef.code('" + type + "', '" + code + "')}";
+                }
+            });
+            Classification def = meta.nameOf(code);
+            return def == null ? null : def.code();
+        } catch (Exception e) {
+            throw new TemplateProcessingException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Get Classification by code.
+     * @param type classification-name
+     * @param code classification element code
+     * @return Classification
+     */
+    public Classification codeOf(String type, String code) {
+        try {
+            final ClassificationMeta meta = findClassificationMeta((String) type, new Supplier<Object>() {
+                public Object get() {
+                    return "${#cdef.codeOf('" + type + "', '" + code + "')}";
+                }
+            });
+            return meta.codeOf(code);
+        } catch (Exception e) {
+            throw new TemplateProcessingException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Get Classification by name.
+     * @param type classification-name
+     * @param name classification element name
+     * @return Classification
+     */
+    public Classification nameOf(String type, String name) {
+        try {
+            final ClassificationMeta meta = findClassificationMeta((String) type, new Supplier<Object>() {
+                public Object get() {
+                    return "${#cdef.nameOf('" + type + "', '" + name + "')}";
+                }
+            });
+            return meta.nameOf(name);
+        } catch (Exception e) {
+            throw new TemplateProcessingException(e.getMessage(), e);
+        }
+    }
+
+    // ===================================================================================
+    //                                                                            Accessor
+    //                                                                            ========
+    protected IProcessingContext getProcessingContext() {
+        return processingContext;
+    }
+
+    protected Locale getUserLocale() {
+        if (getProcessingContext() != null) {
+            return getProcessingContext().getContext().getLocale();
+        }
+        return Locale.getDefault();
+    }
+
+    protected String getRequestTemplatePath() {
+        if (getProcessingContext() instanceof Arguments) {
+            return ((Arguments) getProcessingContext()).getTemplateName();
+        }
+        return null;
+    }
+
+    // ===================================================================================
+    //                                                                      Classification
+    //                                                                      ==============
+    protected ClassificationMeta findClassificationMeta(String classificationName, Supplier<Object> callerInfo) {
+        return provideClassificationMeta(getListedClassificationProvider(), classificationName, callerInfo);
+    }
+
+    protected String findClassificationAlias(Classification cls) {
+        return determineClassificationAliasKey().map(new OptionalThingFunction<String, String>() {
+            @Override
+            public String apply(String key) {
+                return (String) cls.subItemMap().get(key);
+            }
+        }).orElse(cls.alias()); // not lambda for Jetty6
+    }
+
+    protected OptionalThing<String> determineClassificationAliasKey() {
+        return getListedClassificationProvider().determineAlias(getUserLocale());
+    }
+
+    protected ListedClassificationProvider getListedClassificationProvider() {
+        return getAssistantDirector().assistDbDirection().assistListedClassificationProvider();
+    }
+
+    protected ClassificationMeta provideClassificationMeta(ListedClassificationProvider provider, String classificationName,
+            Supplier<Object> callerInfo) {
+        try {
+            return provider.provide(classificationName);
+        } catch (ProvidedClassificationNotFoundException e) {
+            throwListedClassificationNotFoundException(classificationName, callerInfo);
+            return null; // unreachable
+        }
+    }
+
+    protected void throwListedClassificationNotFoundException(String classificationName, Supplier<Object> callerInfo) {
+        final ExceptionMessageBuilder br = new ExceptionMessageBuilder();
+        br.addNotice("Not found the classification for the list.");
+        br.addItem("Requested Template Path");
+        br.addElement(getRequestTemplatePath());
+        br.addItem("Target Expression");
+        br.addElement(callerInfo.get());
+        br.addItem("Classification Name");
+        br.addElement(classificationName);
+        final String msg = br.buildExceptionMessage();
+        throw new TemplateProcessingException(msg);
+    }
+
+    // ===================================================================================
+    //                                                                           Component
+    //                                                                           =========
+    protected FwAssistantDirector getAssistantDirector() {
+        return getComponent(FwAssistantDirector.class);
+    }
+
+    protected <COMPONENT> COMPONENT getComponent(Class<COMPONENT> type) {
+        return ContainerUtil.getComponent(type);
+    }
+}

--- a/src/main/java/org/lastaflute/thymeleaf/processor/ExpressionCDefProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/ExpressionCDefProcessor.java
@@ -51,8 +51,14 @@ import org.thymeleaf.exceptions.TemplateProcessingException;
  */
 public class ExpressionCDefProcessor {
 
+    // ===================================================================================
+    //                                                                           Attribute
+    //                                                                           =========
     private final IProcessingContext processingContext;
 
+    // ===================================================================================
+    //                                                                         Constructor
+    //                                                                         ===========
     public ExpressionCDefProcessor(IProcessingContext processingContext) {
         this.processingContext = processingContext;
     }

--- a/src/main/java/org/lastaflute/thymeleaf/processor/ExpressionHandyDateProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/ExpressionHandyDateProcessor.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.lastaflute.thymeleaf.processor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.dbflute.helper.HandyDate;
+import org.thymeleaf.exceptions.TemplateProcessingException;
+
+/**
+ * Utility methods for LocalDate and more Date objects.<br>
+ * Inner work uses org.dbflute.helper.HandyDate.
+ * <pre>
+ * Usage:
+ *     &lt;span th:text="${#handydate.format(member.birthdate)}"&gt;20XX-XX-XX&lt;/span&gt;
+ *     &lt;span th:text="${#handydate.format(member.birthdate,'yyyy/MM/dd')}"&gt;20XX-XX-XX&lt;/span&gt;
+ *     &lt;span th:text="${#handydate.create(member.birthdate).addYear(10).toDisp('yyyy-MM-dd')}"&gt;20XX-XX-XX&lt;/span&gt;
+ *
+ *   The result of processing this example will be as expected.
+ *     &lt;span&gt;2006-09-26&lt;/span&gt;
+ *     &lt;span&gt;2006/09/26&lt;/span&gt;
+ *     &lt;span&gt;2016-09-26&lt;/span&gt;
+ * </pre>
+ *
+ * @author schatten
+ */
+public class ExpressionHandyDateProcessor {
+
+    /**
+     * Default date format pattern.
+     * HTML input type date is uses this pattern.
+     */
+    public static final String DEFAULT_DATE_FORMAT_PATTERN = "yyyy-MM-dd";
+
+    /**
+     * Create HandyDate object.
+     * @param expression Date expression.(LocalDate, LocalDateTime, Date String)
+     * @return HandyDate
+     */
+    public HandyDate create(Object expression) {
+        if (expression instanceof LocalDate) {
+            return create((LocalDate) expression);
+        }
+        if (expression instanceof LocalDateTime) {
+            return create((LocalDateTime) expression);
+        }
+        if (expression instanceof Date) {
+            return create((Date) expression);
+        }
+        if (expression instanceof String) {
+            return create((String) expression);
+        }
+        String msg = "First argument as one argument should be LocalDate or LocalDateTime or Date or String(expression).";
+        throw new TemplateProcessingException(msg);
+    }
+
+    /**
+     * Create HandyDate object.
+     * @param expression Date expression.(LocalDate, LocalDateTime, Date String)
+     * @param arg2 TimeZone or Date String parse pattern.
+     * @return HandyDate
+     */
+    public HandyDate create(Object expression, Object arg2) {
+        if (arg2 instanceof TimeZone) {
+            if (expression instanceof LocalDate) {
+                return create((LocalDate) expression, (TimeZone) arg2);
+            }
+            if (expression instanceof LocalDateTime) {
+                return create((LocalDateTime) expression, (TimeZone) arg2);
+            }
+            if (expression instanceof String) {
+                return create((String) expression, (TimeZone) arg2);
+            }
+            String msg =
+                    "First argument as two arguments should be LocalDate or LocalDateTime or String(expression) when second argument is TimeZone.";
+            throw new TemplateProcessingException(msg);
+        }
+        if (arg2 instanceof String) {
+            if (expression instanceof String) {
+                return create((String) expression, (String) arg2);
+            }
+            String msg = "First argument as two arguments should be String when second argument is String(pattern).";
+            throw new TemplateProcessingException(msg);
+        }
+        String msg = "Second argument as two arguments should be TimeZone or String(pattern).";
+        throw new TemplateProcessingException(msg);
+    }
+
+    public HandyDate create(Object expression, Object pattern, Object locale) {
+        if (!(expression instanceof String)) {
+            String msg = "First argument as three arguments should be String(expression).";
+            throw new TemplateProcessingException(msg);
+        }
+        if (!(pattern instanceof String)) {
+            String msg = "Second argument as three arguments should be TimeZone or String(pattern).";
+            throw new TemplateProcessingException(msg);
+        }
+        if (!(locale instanceof Locale)) {
+            String msg = "Third argument as three arguments should be Locale.";
+            throw new TemplateProcessingException(msg);
+        }
+        return create((String) expression, (String) pattern, (Locale) locale);
+    }
+
+    public HandyDate create(Object expression, Object timeZone, Object pattern, Object locale) {
+        if (!(expression instanceof String)) {
+            String msg = "First argument as four arguments should be String(expression).";
+            throw new TemplateProcessingException(msg);
+        }
+        if (!(timeZone instanceof TimeZone)) {
+            String msg = "Second argument as four arguments should be TimeZone.";
+            throw new TemplateProcessingException(msg);
+        }
+        if (!(pattern instanceof String)) {
+            String msg = "Third argument as four arguments should be TimeZone or String(pattern).";
+            throw new TemplateProcessingException(msg);
+        }
+        if (!(locale instanceof Locale)) {
+            String msg = "Fourth argument as four arguments should be Locale.";
+            throw new TemplateProcessingException(msg);
+        }
+        return create((String) expression, (TimeZone) timeZone, (String) pattern, (Locale) locale);
+    }
+
+    /**
+     * Get formatted date string.
+     * Using pattern of default.
+     * @param expression Date expression.
+     * @return formatted date string.(Return null if expression is null.)
+     */
+    public String format(Object expression) {
+        return format(expression, DEFAULT_DATE_FORMAT_PATTERN);
+    }
+
+    /**
+     * Get formatted date string.
+     * @param expression Date expression.
+     * @param pattern date format pattern.
+     * @return formatted date string.(Return null if expression is null.)
+     */
+    public String format(Object expression, Object pattern) {
+        if (pattern instanceof String) {
+            if (expression == null) {
+                return null;
+            }
+            if (expression instanceof LocalDate) {
+                return create((LocalDate) expression).toDisp((String) pattern);
+            }
+            if (expression instanceof LocalDateTime) {
+                return create((LocalDateTime) expression).toDisp((String) pattern);
+            }
+            if (expression instanceof Date) {
+                return create((Date) expression).toDisp((String) pattern);
+            }
+            if (expression instanceof String) {
+                return create((String) expression).toDisp((String) pattern);
+            }
+            String msg = "First argument as two arguments should be LocalDate or LocalDateTime or Date or String(expression).";
+            throw new TemplateProcessingException(msg);
+        }
+        String msg = "Second argument as two arguments should be String(pattern).";
+        throw new TemplateProcessingException(msg);
+    }
+
+    /**
+     * Create HandyDate from LocalDate.
+     * @param localDate
+     * @return HandyDate
+     * @see HandyDate#HandyDate(LocalDate)
+     */
+    public static HandyDate create(LocalDate localDate) {
+        return new HandyDate(localDate);
+    }
+
+    /**
+     * Create HandyDate from LocalDate.
+     * @param localDate
+     * @param timeZone
+     * @return HandyDate
+     * @see HandyDate#HandyDate(LocalDate, TimeZone)
+     */
+    public static HandyDate create(LocalDate localDate, TimeZone timeZone) {
+        return new HandyDate(localDate, timeZone);
+    }
+
+    /**
+     * Create HandyDate from LocalDateTime.
+     * @param localDateTime
+     * @return HandyDate
+     * @see HandyDate#HandyDate(LocalDateTime)
+     */
+    public static HandyDate create(LocalDateTime localDateTime) {
+        return new HandyDate(localDateTime);
+    }
+
+    /**
+     * Create HandyDate from LocalDateTime.
+     * @param localDateTime
+     * @param timeZone
+     * @return HandyDate
+     * @see HandyDate#HandyDate(LocalDateTime, TimeZone)
+     */
+    public static HandyDate create(LocalDateTime localDateTime, TimeZone timeZone) {
+        return new HandyDate(localDateTime, timeZone);
+    }
+
+    /**
+     * Create HandyDate from Date.
+     * @param date
+     * @return HandyDate
+     * @see HandyDate#HandyDate(Date)
+     */
+    public static HandyDate create(Date date) {
+        return new HandyDate(date);
+    }
+
+    /**
+     * Create HandyDate from String.
+     * @param exp
+     * @return HandyDate
+     * @see HandyDate#HandyDate(String)
+     */
+    public static HandyDate create(String exp) {
+        return new HandyDate(exp);
+    }
+
+    /**
+     * Create HandyDate from string with TimeZone.
+     * @param exp
+     * @param timeZone
+     * @return HandyDate
+     * @see HandyDate#HandyDate(String, TimeZone)
+     */
+    public static HandyDate create(String exp, TimeZone timeZone) {
+        return new HandyDate(exp, timeZone);
+    }
+
+    /**
+     * Create HandyDate from date string with parse pattern.
+     * @param exp
+     * @param pattern
+     * @return HandyDate
+     * @see HandyDate#HandyDate(String, String)
+     */
+    public static HandyDate create(String exp, String pattern) {
+        return new HandyDate(exp, pattern);
+    }
+
+    /**
+     * Create HandyDate from date string with parse pattern and locale.
+     * @param exp
+     * @param pattern
+     * @param locale
+     * @return HandyDate
+     * @see HandyDate#HandyDate(String, String, Locale)
+     */
+    public static HandyDate create(String exp, String pattern, Locale locale) {
+        return new HandyDate(exp, pattern, locale);
+    }
+
+    /**
+     * Create HandyDate from date string with TimeZone, parse pattern and locale.
+     * @param exp
+     * @param timeZone
+     * @param pattern
+     * @param locale
+     * @return HandyDate
+     * @see HandyDate#HandyDate(String, TimeZone, String, Locale)
+     */
+    public static HandyDate create(String exp, TimeZone timeZone, String pattern, Locale locale) {
+        return new HandyDate(exp, timeZone, pattern, locale);
+    }
+}

--- a/src/main/java/org/lastaflute/thymeleaf/processor/ExpressionHandyDateProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/ExpressionHandyDateProcessor.java
@@ -43,12 +43,18 @@ import org.thymeleaf.exceptions.TemplateProcessingException;
  */
 public class ExpressionHandyDateProcessor {
 
+    // ===================================================================================
+    //                                                                          Definition
+    //                                                                          ==========
     /**
      * Default date format pattern.
      * HTML input type date is uses this pattern.
      */
     public static final String DEFAULT_DATE_FORMAT_PATTERN = "yyyy-MM-dd";
 
+    // ===================================================================================
+    //                                                                          Expression
+    //                                                                          ==========
     /**
      * Create HandyDate object.
      * @param expression Date expression.(LocalDate, LocalDateTime, Date String)
@@ -103,6 +109,13 @@ public class ExpressionHandyDateProcessor {
         throw new TemplateProcessingException(msg);
     }
 
+    /**
+     * Create HandyDate object.
+     * @param expression String date (String)
+     * @param pattern date format pattern (String)
+     * @param locale date locale (Locale)
+     * @return HandyDate
+     */
     public HandyDate create(Object expression, Object pattern, Object locale) {
         if (!(expression instanceof String)) {
             String msg = "First argument as three arguments should be String(expression).";
@@ -119,6 +132,14 @@ public class ExpressionHandyDateProcessor {
         return create((String) expression, (String) pattern, (Locale) locale);
     }
 
+    /**
+     * Create HandyDate object.
+     * @param expression String date (String)
+     * @param timeZone Time zone (TimeZone)
+     * @param pattern date format pattern (String)
+     * @param locale dat locale (Locale)
+     * @return HandyDate
+     */
     public HandyDate create(Object expression, Object timeZone, Object pattern, Object locale) {
         if (!(expression instanceof String)) {
             String msg = "First argument as four arguments should be String(expression).";
@@ -179,6 +200,9 @@ public class ExpressionHandyDateProcessor {
         throw new TemplateProcessingException(msg);
     }
 
+    // ===================================================================================
+    //                                                                    Delegate Utility
+    //                                                                    ================
     /**
      * Create HandyDate from LocalDate.
      * @param localDate

--- a/src/main/java/org/lastaflute/thymeleaf/processor/ForEachAttrProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/ForEachAttrProcessor.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.lastaflute.thymeleaf.processor;
+
+import org.lastaflute.thymeleaf.internal.processor.attr.AbstractIterationAttrProcessor;
+import org.thymeleaf.Arguments;
+import org.thymeleaf.Configuration;
+import org.thymeleaf.dom.Element;
+import org.thymeleaf.exceptions.TemplateProcessingException;
+import org.thymeleaf.standard.expression.Each;
+import org.thymeleaf.standard.expression.EachUtils;
+import org.thymeleaf.standard.expression.IStandardExpression;
+import org.thymeleaf.standard.expression.SelectionVariableExpression;
+import org.thymeleaf.standard.expression.VariableExpression;
+import org.thymeleaf.util.StringUtils;
+
+/**
+ * Foreach Attribute Processor.
+ * Base function is Same to {@link org.thymeleaf.standard.processor.attr.StandardEachAttrProcessor StandardEachAttrProcessor}.<br>
+ * Add Support to write array name variable with list form property to name attribute.
+ * <pre>
+ * Usage: e.g.
+ *
+ *   [HTML]
+ *     &lt;dl la:foreach="item : <b>${items}</b>"&gt;
+ *       &lt;dt la:property="item.product.name"&gt;Sample Name&lt;/dt&gt;
+ *       &lt;dd&gt;Qty:&lt;input la:property="item.quantity"/&gt;&lt;/dd&gt;
+ *     &lt;/dl&gt;
+ *
+ *   [Form Bean]
+ *     public class PurchaseForm {
+ *         public List&lt;CartProduct&gt; items;
+ *         ...
+ *     }
+ *     public class CartProduct {
+ *         public Product product;
+ *         public Integer quantity;
+ *         ...
+ *     }
+ *
+ * The result of processing this example will be as expected.
+ *     &lt;dl&gt;
+ *       &lt;dt&gt;Rosemary (100g)&lt;/dt&gt;
+ *       &lt;dd&gt;Qty:&lt;input <b>name="items[0].quantity"</b> value=""/&gt;&lt;/dd&gt;
+ *     &lt;/dl&gt;
+ *     &lt;dl&gt;
+ *       &lt;dt&gt;Lemon Grass (100g)&lt;/dt&gt;
+ *       &lt;dd&gt;Qty:&lt;input <b>name="items[1].quantity"</b> value=""/&gt;&lt;/dd&gt;
+ *     &lt;/dl&gt;
+ *
+ * </pre>
+ * @author schatten
+ * @see org.thymeleaf.standard.processor.attr.StandardEachAttrProcessor StandardEachAttrProcessor(Original)
+ */
+public class ForEachAttrProcessor extends AbstractIterationAttrProcessor {
+
+    public static final int ATTR_PRECEDENCE = 200;
+    public static final String ATTR_NAME = "foreach";
+
+    protected static final String ITERATION_SPEC_VAR_SUFFIX = "Spec";
+    public static final String FORM_PROPERTY_PATH_VER = "foreach_form_property_path";
+
+
+    protected ForEachAttrProcessor() {
+        super(ATTR_NAME);
+    }
+
+    @Override
+    public int getPrecedence() {
+        return ATTR_PRECEDENCE;
+    }
+
+    /**
+     * @see org.thymeleaf.standard.processor.attr.AbstractStandardIterationAttrProcessor#processClonedHostIterationElement(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String)
+     */
+    @Override
+    protected void processClonedHostIterationElement(Arguments arguments, Element iteratedChild, String attributeName) {
+        // Nothing to be done here, no additional processings for iterated elements
+    }
+
+    /**
+     * @see org.thymeleaf.standard.processor.attr.AbstractStandardIterationAttrProcessor#getIterationSpec(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String)
+     */
+    @Override
+    protected final IterationSpec getIterationSpec(
+            final Arguments arguments, final Element element, final String attributeName) {
+
+        final String attributeValue = element.getAttributeValue(attributeName);
+
+        final Configuration configuration = arguments.getConfiguration();
+
+        final Each each = EachUtils.parseEach(configuration, arguments, attributeValue);
+
+        final IStandardExpression iterVarExpr = each.getIterVar();
+        final Object iterVarValue = iterVarExpr.execute(configuration, arguments);
+
+        final IStandardExpression statusVarExpr = each.getStatusVar();
+        final Object statusVarValue;
+        if (statusVarExpr != null) {
+            statusVarValue = statusVarExpr.execute(configuration, arguments);
+        } else {
+            statusVarValue = null;
+        }
+
+        final IStandardExpression iterableExpr = each.getIterable();
+        final Object iteratedValue = iterableExpr.execute(configuration, arguments);
+
+        final String iterVarName = (iterVarValue == null ? null : iterVarValue.toString());
+        if (StringUtils.isEmptyOrWhitespace(iterVarName)) {
+            throw new TemplateProcessingException(
+                    "Iteration variable name expression evaluated as null: \"" + iterVarExpr + "\"");
+        }
+
+        final String statusVarName = (statusVarValue == null ? null : statusVarValue.toString());
+        if (statusVarExpr != null && StringUtils.isEmptyOrWhitespace(statusVarName)) {
+            throw new TemplateProcessingException(
+                    "Status variable name expression evaluated as null or empty: \"" + statusVarExpr + "\"");
+        }
+
+        // Extends form property path access.
+        String currentPropertyName = getCurrentPropertyNameFromIterVarExpr(iterableExpr);
+        if (currentPropertyName != null) {
+            String parentPath = (String) arguments.getLocalVariable(FORM_PROPERTY_PATH_VER);
+            String propertyPath = parentPath == null ? currentPropertyName : parentPath + "." + currentPropertyName;
+            return new ForEachIterationSpec(iterVarName, statusVarName, iteratedValue, propertyPath);
+        }
+        return new IterationSpec(iterVarName, statusVarName, iteratedValue);
+
+    }
+
+    protected String getCurrentPropertyNameFromIterVarExpr(IStandardExpression iterVarExpr) {
+        String expression;
+        if (iterVarExpr instanceof SelectionVariableExpression) {
+            expression = ((SelectionVariableExpression) iterVarExpr).getExpression();
+        } else if (iterVarExpr instanceof VariableExpression) {
+            expression = ((VariableExpression) iterVarExpr).getExpression();
+        } else {
+            return null;
+        }
+        int lastIndexOf = expression.lastIndexOf(".");
+        if (lastIndexOf < 0) {
+            return expression;
+        }
+        return expression.substring(lastIndexOf + 1);
+    }
+
+    /**
+     * @see org.lastaflute.thymeleaf.internal.processor.attr.AbstractIterationAttrProcessor#prepareLocalVariablesForEachIterationItem(org.thymeleaf.dom.Element, org.lastaflute.thymeleaf.internal.processor.attr.AbstractIterationAttrProcessor.IterationSpec, int, int, java.lang.Object) Internal
+     * @see org.thymeleaf.processor.attr.AbstractIterationAttrProcessor#processAttribute(Arguments, Element, String) Original
+     */
+    @Override
+    protected void prepareLocalVariablesForEachIterationItem(final Element clonedElement, final IterationSpec iterationSpec,
+            final int size, int index, final Object obj) {
+        final String iterVar = iterationSpec.getIterVarName();
+        final String statusVar = iterationSpec.getStatusVarName();
+        /*
+         * Prepare local variables that will be available for each iteration item
+         */
+        clonedElement.setNodeLocalVariable(iterVar, obj);
+        StatusVar status;
+        if (iterationSpec instanceof ForEachIterationSpec) {
+            String formNamePath = String.format("%s[%d]", ((ForEachIterationSpec) iterationSpec).getPropertyPath(), index);
+            status = new ForEachStatusVar(index, index + 1, size, obj, formNamePath);
+            clonedElement.setNodeLocalVariable(FORM_PROPERTY_PATH_VER, formNamePath);
+        } else {
+            status = new StatusVar(index, index + 1, size, obj);
+        }
+        if (statusVar != null) {
+            clonedElement.setNodeLocalVariable(statusVar, status);
+        } else {
+            clonedElement.setNodeLocalVariable(iterVar + DEFAULT_STATUS_VAR_SUFFIX, status);
+        }
+        clonedElement.setNodeLocalVariable(iterVar + ITERATION_SPEC_VAR_SUFFIX, iterationSpec);
+    }
+
+    public static class ForEachStatusVar extends StatusVar {
+
+        private final String propertyPath;
+
+        public ForEachStatusVar(int index, int count, int size, Object current) {
+            super(index, count, size, current);
+            this.propertyPath = null;
+        }
+
+        public ForEachStatusVar(int index, int count, int size, Object current, String propertyPath) {
+            super(index, count, size, current);
+            this.propertyPath = propertyPath;
+        }
+
+        public String getPropertyPath() {
+            return propertyPath;
+        }
+    }
+
+    public static class ForEachIterationSpec extends IterationSpec {
+        private final String propertyPath;
+
+        public ForEachIterationSpec(String iterVarName, String statusVarName, Object iteratedObject, String propertyPath) {
+            super(iterVarName, statusVarName, iteratedObject);
+            this.propertyPath = propertyPath;
+        }
+
+        public String getPropertyPath() {
+            return this.propertyPath;
+        }
+    }
+}

--- a/src/main/java/org/lastaflute/thymeleaf/processor/ForEachAttrProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/ForEachAttrProcessor.java
@@ -67,23 +67,36 @@ import org.thymeleaf.util.StringUtils;
  */
 public class ForEachAttrProcessor extends AbstractIterationAttrProcessor {
 
+    // ===================================================================================
+    //                                                                          Definition
+    //                                                                          ==========
     public static final int ATTR_PRECEDENCE = 200;
     public static final String ATTR_NAME = "foreach";
 
     protected static final String ITERATION_SPEC_VAR_SUFFIX = "Spec";
     public static final String FORM_PROPERTY_PATH_VER = "foreach_form_property_path";
 
-
+    // ===================================================================================
+    //                                                                         Constructor
+    //                                                                         ===========
     protected ForEachAttrProcessor() {
         super(ATTR_NAME);
     }
 
+    // ===================================================================================
+    //                                                                          Implements
+    //                                                                          ==========
+    /**
+     * {@inheritDoc}
+     * @see org.thymeleaf.processor.AbstractProcessor#getPrecedence()
+     */
     @Override
     public int getPrecedence() {
         return ATTR_PRECEDENCE;
     }
 
     /**
+     * @see org.lastaflute.thymeleaf.internal.processor.attr.AbstractIterationAttrProcessor#processClonedHostIterationElement(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String)
      * @see org.thymeleaf.standard.processor.attr.AbstractStandardIterationAttrProcessor#processClonedHostIterationElement(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String)
      */
     @Override
@@ -92,6 +105,7 @@ public class ForEachAttrProcessor extends AbstractIterationAttrProcessor {
     }
 
     /**
+     * @see org.lastaflute.thymeleaf.internal.processor.attr.AbstractIterationAttrProcessor#getIterationSpec(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String)
      * @see org.thymeleaf.standard.processor.attr.AbstractStandardIterationAttrProcessor#getIterationSpec(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String)
      */
     @Override
@@ -186,6 +200,9 @@ public class ForEachAttrProcessor extends AbstractIterationAttrProcessor {
         clonedElement.setNodeLocalVariable(iterVar + ITERATION_SPEC_VAR_SUFFIX, iterationSpec);
     }
 
+    // ===================================================================================
+    //                                                                     Internal Object
+    //                                                                     ===============
     public static class ForEachStatusVar extends StatusVar {
 
         private final String propertyPath;

--- a/src/main/java/org/lastaflute/thymeleaf/processor/LastaThymeleafDialect.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/LastaThymeleafDialect.java
@@ -64,6 +64,7 @@ public class LastaThymeleafDialect extends AbstractXHTMLEnabledDialect implement
         final Set<IProcessor> processors = new LinkedHashSet<IProcessor>();
         processors.add(new PropertyAttrProcessor());
         processors.add(new OptionClsAttrProcessor());
+        processors.add(new ForEachAttrProcessor());
         return processors;
     }
 

--- a/src/main/java/org/lastaflute/thymeleaf/processor/LastaThymeleafDialect.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/LastaThymeleafDialect.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.lastaflute.thymeleaf.processor;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.thymeleaf.Configuration;
+import org.thymeleaf.context.IProcessingContext;
+import org.thymeleaf.dialect.AbstractXHTMLEnabledDialect;
+import org.thymeleaf.dialect.IExpressionEnhancingDialect;
+import org.thymeleaf.processor.IProcessor;
+
+/**
+ * Lasta Thymeleaf Dialect.
+ * @author schatten
+ */
+public class LastaThymeleafDialect extends AbstractXHTMLEnabledDialect implements IExpressionEnhancingDialect {
+
+    protected static final String LASTA_TYMELEAF_DIALECT_PREFIX = "df";
+
+    protected final Configuration configuration;
+    private final Set<IProcessor> additionalProcessors = new LinkedHashSet<IProcessor>();
+
+    public LastaThymeleafDialect(Configuration configuration) {
+        super();
+        this.configuration = configuration;
+    }
+
+    @Override
+    public String getPrefix() {
+        return LASTA_TYMELEAF_DIALECT_PREFIX;
+    }
+
+    @Override
+    public Set<IProcessor> getProcessors() {
+        final Set<IProcessor> processors = createLastaProcessorsSet();
+        final Set<IProcessor> dialectAdditionalProcessors = getAdditionalProcessors();
+
+        if (!dialectAdditionalProcessors.isEmpty()) {
+            processors.addAll(dialectAdditionalProcessors);
+        }
+
+        return new LinkedHashSet<IProcessor>(processors);
+    }
+
+    public static Set<IProcessor> createLastaProcessorsSet() {
+        final Set<IProcessor> processors = new LinkedHashSet<IProcessor>();
+        // TODO Create custom processor
+        return processors;
+    }
+
+    public Set<IProcessor> getAdditionalProcessors() {
+        return Collections.unmodifiableSet(this.additionalProcessors);
+    }
+
+    public void addAdditionalProcessor(IProcessor processor) {
+        this.additionalProcessors.add(processor);
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalExpressionObjects(IProcessingContext processingContext) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("handydate", new ExpressionHandyDateProcessor());
+        map.put("cdef", new ExpressionCDefProcessor(processingContext));
+        return map;
+    }
+
+}

--- a/src/main/java/org/lastaflute/thymeleaf/processor/LastaThymeleafDialect.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/LastaThymeleafDialect.java
@@ -62,7 +62,8 @@ public class LastaThymeleafDialect extends AbstractXHTMLEnabledDialect implement
 
     public static Set<IProcessor> createLastaProcessorsSet() {
         final Set<IProcessor> processors = new LinkedHashSet<IProcessor>();
-        // TODO Create custom processor
+        processors.add(new PropertyAttrProcessor());
+        processors.add(new OptionClsAttrProcessor());
         return processors;
     }
 

--- a/src/main/java/org/lastaflute/thymeleaf/processor/LastaThymeleafDialect.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/LastaThymeleafDialect.java
@@ -33,7 +33,7 @@ import org.thymeleaf.processor.IProcessor;
  */
 public class LastaThymeleafDialect extends AbstractXHTMLEnabledDialect implements IExpressionEnhancingDialect {
 
-    protected static final String LASTA_TYMELEAF_DIALECT_PREFIX = "df";
+    protected static final String LASTA_TYMELEAF_DIALECT_PREFIX = "la";
 
     protected final Configuration configuration;
     private final Set<IProcessor> additionalProcessors = new LinkedHashSet<IProcessor>();

--- a/src/main/java/org/lastaflute/thymeleaf/processor/LastaThymeleafDialect.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/LastaThymeleafDialect.java
@@ -33,21 +33,40 @@ import org.thymeleaf.processor.IProcessor;
  */
 public class LastaThymeleafDialect extends AbstractXHTMLEnabledDialect implements IExpressionEnhancingDialect {
 
+    // ===================================================================================
+    //                                                                          Definition
+    //                                                                          ==========
     protected static final String LASTA_TYMELEAF_DIALECT_PREFIX = "la";
 
+    // ===================================================================================
+    //                                                                           Attribute
+    //                                                                           =========
     protected final Configuration configuration;
     private final Set<IProcessor> additionalProcessors = new LinkedHashSet<IProcessor>();
 
+    // ===================================================================================
+    //                                                                         Constructor
+    //                                                                         ===========
     public LastaThymeleafDialect(Configuration configuration) {
         super();
         this.configuration = configuration;
     }
 
+    // ===================================================================================
+    //                                                                          Implements
+    //                                                                          ==========
+    /**
+     * Get prefix of attribute name.
+     * @see org.thymeleaf.dialect.IDialect#getPrefix()
+     */
     @Override
     public String getPrefix() {
         return LASTA_TYMELEAF_DIALECT_PREFIX;
     }
 
+    /**
+     * @see org.thymeleaf.dialect.AbstractDialect#getProcessors()
+     */
     @Override
     public Set<IProcessor> getProcessors() {
         final Set<IProcessor> processors = createLastaProcessorsSet();
@@ -60,6 +79,17 @@ public class LastaThymeleafDialect extends AbstractXHTMLEnabledDialect implement
         return new LinkedHashSet<IProcessor>(processors);
     }
 
+    /**
+     * @see org.thymeleaf.dialect.IExpressionEnhancingDialect#getAdditionalExpressionObjects(org.thymeleaf.context.IProcessingContext)
+     */
+    @Override
+    public Map<String, Object> getAdditionalExpressionObjects(IProcessingContext processingContext) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("handydate", new ExpressionHandyDateProcessor());
+        map.put("cdef", new ExpressionCDefProcessor(processingContext));
+        return map;
+    }
+
     public static Set<IProcessor> createLastaProcessorsSet() {
         final Set<IProcessor> processors = new LinkedHashSet<IProcessor>();
         processors.add(new PropertyAttrProcessor());
@@ -68,6 +98,9 @@ public class LastaThymeleafDialect extends AbstractXHTMLEnabledDialect implement
         return processors;
     }
 
+    // ===================================================================================
+    //                                                                            Accessor
+    //                                                                            ========
     public Set<IProcessor> getAdditionalProcessors() {
         return Collections.unmodifiableSet(this.additionalProcessors);
     }
@@ -76,12 +109,5 @@ public class LastaThymeleafDialect extends AbstractXHTMLEnabledDialect implement
         this.additionalProcessors.add(processor);
     }
 
-    @Override
-    public Map<String, Object> getAdditionalExpressionObjects(IProcessingContext processingContext) {
-        Map<String, Object> map = new HashMap<>();
-        map.put("handydate", new ExpressionHandyDateProcessor());
-        map.put("cdef", new ExpressionCDefProcessor(processingContext));
-        return map;
-    }
 
 }

--- a/src/main/java/org/lastaflute/thymeleaf/processor/OptionClsAttrProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/OptionClsAttrProcessor.java
@@ -71,19 +71,36 @@ import org.thymeleaf.util.Validate;
  */
 public class OptionClsAttrProcessor extends AbstractAttributeModifierAttrProcessor {
 
+    // ===================================================================================
+    //                                                                          Definition
+    //                                                                          ==========
     protected static final String OPTION_CLS_ATTRIBUTE_NAME = "optionCls";
     private static final String OPTION_CLS_ELEMENT_TARGET = "option";
     private static final String DEFAULT_ITERATION_VALUE = "opdef";
 
+    // ===================================================================================
+    //                                                                         Constructor
+    //                                                                         ===========
     protected OptionClsAttrProcessor() {
         super(new AttributeNameProcessorMatcher(OPTION_CLS_ATTRIBUTE_NAME, OPTION_CLS_ELEMENT_TARGET));
     }
 
+    // ===================================================================================
+    //                                                                          Implements
+    //                                                                          ==========
+    /**
+     * {@inheritDoc}
+     * @see org.thymeleaf.processor.AbstractProcessor#getPrecedence()
+     */
     @Override
     public int getPrecedence() {
         return 200;
     }
 
+    /**
+     * {@inheritDoc}
+     * @see org.thymeleaf.processor.attr.AbstractAttributeModifierAttrProcessor#getModifiedAttributeValues(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String)
+     */
     @Override
     protected Map<String, String> getModifiedAttributeValues(Arguments arguments, Element element, String attributeName) {
 
@@ -116,16 +133,28 @@ public class OptionClsAttrProcessor extends AbstractAttributeModifierAttrProcess
         return getParentSelectPropertyName((Element)element.getParent());
     }
 
+    /**
+     * {@inheritDoc}
+     * @see org.thymeleaf.processor.attr.AbstractAttributeModifierAttrProcessor#getModificationType(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String, java.lang.String)
+     */
     @Override
     protected ModificationType getModificationType(Arguments arguments, Element element, String attributeName, String newAttributeName) {
         return ModificationType.SUBSTITUTION;
     }
 
+    /**
+     * {@inheritDoc}
+     * @see org.thymeleaf.processor.attr.AbstractAttributeModifierAttrProcessor#removeAttributeIfEmpty(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String, java.lang.String)
+     */
     @Override
     protected boolean removeAttributeIfEmpty(Arguments arguments, Element element, String attributeName, String newAttributeName) {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     * @see org.thymeleaf.processor.attr.AbstractAttributeModifierAttrProcessor#recomputeProcessorsAfterExecution(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String)
+     */
     @Override
     protected boolean recomputeProcessorsAfterExecution(Arguments arguments, Element element, String attributeName) {
         return true;
@@ -166,6 +195,9 @@ public class OptionClsAttrProcessor extends AbstractAttributeModifierAttrProcess
         return new IterationSpec(iterVarName, statusVarName, classificationName);
     }
 
+    // ===================================================================================
+    //                                                                     Internal Object
+    //                                                                     ===============
     protected static class IterationSpec {
 
         private final String iterVarName;

--- a/src/main/java/org/lastaflute/thymeleaf/processor/OptionClsAttrProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/OptionClsAttrProcessor.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.lastaflute.thymeleaf.processor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.thymeleaf.Arguments;
+import org.thymeleaf.Configuration;
+import org.thymeleaf.dom.Element;
+import org.thymeleaf.processor.AttributeNameProcessorMatcher;
+import org.thymeleaf.processor.attr.AbstractAttributeModifierAttrProcessor;
+import org.thymeleaf.processor.attr.AbstractIterationAttrProcessor;
+import org.thymeleaf.standard.StandardDialect;
+import org.thymeleaf.standard.expression.IStandardExpression;
+import org.thymeleaf.standard.expression.IStandardExpressionParser;
+import org.thymeleaf.standard.expression.StandardExpressions;
+import org.thymeleaf.util.Validate;
+
+/**
+ * Processor for Option Attribute of Select Tag with Classification Definition.
+ * <pre>
+ * Usage:
+ *   &lt;select <b>la:property="status"</b>&gt;
+ *     &lt;option&gt;&lt;/option&gt;
+ *     &lt;option <b>la:optionCls="'MemberStatus'"</b>&gt;&lt;/option&gt;
+ *   &lt;/select&gt;
+ *
+ * This means is :
+ *   &lt;select name="status"&gt;
+ *     &lt;option&gt;&lt;/option&gt;
+ *     &lt;option <b>th:each="opdef : ${#cdef.values('MemberStatus')}" th:value="${#cdef.code(opdef)}" th:text="${#cdef.alias(opdef)}"</b> th:selected="${opdef} == ${status}"&gt;&lt;/option&gt;
+ *   &lt;/select&gt;
+ *
+ * The result of processing this example will be as expected.
+ *   &lt;select name="status"&gt;
+ *     &lt;option&gt;&lt;/option&gt;
+ *     &lt;option selected="selected" value="FML"&gt;Formalized&lt;/option&gt;
+ *     &lt;option value="WDL"&gt;Withdrawal&lt;/option&gt;
+ *     &lt;option value="PRV"&gt;Provisional&lt;/option&gt;
+ *   &lt;/select&gt;
+ *
+ * 2.If Custom text use.("prod" is iteration variable)
+ *   &lt;select la:proparty="status"&gt;
+ *     &lt;option&gt;&lt;/option&gt;
+ *     &lt;option <b>la:optionCls="prod : 'MemberStatus'"</b> th:text="${#cdef.code(prod)} + ' : ' + ${#cdef.alias(prod)}"&gt;&lt;/option&gt;
+ *   &lt;/select&gt;
+ *
+ * The result of processing this example will be as expected.
+ *   &lt;select name="status"&gt;
+ *     &lt;option&gt;&lt;/option&gt;
+ *     &lt;option selected="selected" value="FML"&gt;FML : Formalized&lt;/option&gt;
+ *     &lt;option value="WDL"&gt;WDL : Withdrawal&lt;/option&gt;
+ *     &lt;option value="PRV"&gt;PRV : Provisional&lt;/option&gt;
+ *   &lt;/select&gt;
+ * </pre>
+ * @author schatten
+ */
+public class OptionClsAttrProcessor extends AbstractAttributeModifierAttrProcessor {
+
+    protected static final String OPTION_CLS_ATTRIBUTE_NAME = "optionCls";
+    private static final String OPTION_CLS_ELEMENT_TARGET = "option";
+    private static final String DEFAULT_ITERATION_VALUE = "opdef";
+
+    protected OptionClsAttrProcessor() {
+        super(new AttributeNameProcessorMatcher(OPTION_CLS_ATTRIBUTE_NAME, OPTION_CLS_ELEMENT_TARGET));
+    }
+
+    @Override
+    public int getPrecedence() {
+        return 200;
+    }
+
+    @Override
+    protected Map<String, String> getModifiedAttributeValues(Arguments arguments, Element element, String attributeName) {
+
+        IterationSpec spec = getIterationSpec(arguments, element, attributeName);
+
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("th:each", String.format("%s, %s : ${#cdef.values('%s')}", spec.getIterVarName(), spec.getStatusVarName() ,spec.getClassificationName()));
+        if (!element.hasNormalizedAttribute(StandardDialect.PREFIX, "value")) {
+            map.put("th:value", String.format("${#cdef.code(%s)}",spec.getIterVarName()));
+        }
+        if (!element.hasNormalizedAttribute(StandardDialect.PREFIX, "text")) {
+            map.put("th:text", String.format("${#cdef.alias(%s)}",spec.getIterVarName()));
+        }
+        if (!element.hasNormalizedAttribute(StandardDialect.PREFIX, "selected")) {
+            String selectPropertyNamme = getParentSelectPropertyName(element);
+            if (selectPropertyNamme != null) {
+                map.put("th:selected", String.format("${%s.code()} == ${%s}", spec.getIterVarName(), selectPropertyNamme));
+            }
+        }
+        return map;
+    }
+
+    protected String getParentSelectPropertyName(Element element) {
+        if (element.hasNodeProperty(PropertyAttrProcessor.SELECT_PROPERTY_NAME)) {
+            return (String)element.getNodeProperty(PropertyAttrProcessor.SELECT_PROPERTY_NAME);
+        }
+        if ("select".equals(element.getNormalizedName())) {
+            return null;
+        }
+        return getParentSelectPropertyName((Element)element.getParent());
+    }
+
+    @Override
+    protected ModificationType getModificationType(Arguments arguments, Element element, String attributeName, String newAttributeName) {
+        return ModificationType.SUBSTITUTION;
+    }
+
+    @Override
+    protected boolean removeAttributeIfEmpty(Arguments arguments, Element element, String attributeName, String newAttributeName) {
+        return true;
+    }
+
+    @Override
+    protected boolean recomputeProcessorsAfterExecution(Arguments arguments, Element element, String attributeName) {
+        return true;
+    }
+
+    protected IterationSpec getIterationSpec(final Arguments arguments, final Element element, final String attributeName) {
+        final Configuration configuration = arguments.getConfiguration();
+
+        // Obtain the Thymeleaf Standard Expression parser
+        final IStandardExpressionParser parser = StandardExpressions.getExpressionParser(configuration);
+
+        // Obtain the attribute value
+        final String attributeValue = element.getAttributeValue(attributeName);
+        int separateIndex = attributeValue.indexOf(":");
+        if (separateIndex < 0) {
+            // Parse the attribute value as a Thymeleaf Standard Expression
+            final IStandardExpression expression = parser.parseExpression(configuration, arguments, attributeValue);
+
+            String classificationName = expression.execute(configuration, arguments).toString();
+            return new IterationSpec(DEFAULT_ITERATION_VALUE, DEFAULT_ITERATION_VALUE + AbstractIterationAttrProcessor.DEFAULT_STATUS_VAR_SUFFIX, classificationName);
+        }
+
+        String classification = attributeValue.substring(separateIndex + 1).trim();
+        String iterVarName = attributeValue.substring(0, separateIndex).trim();
+        String statusVarName = null;
+        int statusSeparate = iterVarName.indexOf(",");
+        if (statusSeparate < 0) {
+            statusVarName = iterVarName + AbstractIterationAttrProcessor.DEFAULT_STATUS_VAR_SUFFIX;
+        } else {
+            statusVarName = iterVarName.substring(statusSeparate + 1).trim();
+            iterVarName = iterVarName.substring(0, statusSeparate).trim();
+        }
+        // Parse the attribute value as a Thymeleaf Standard Expression
+        final IStandardExpression expression = parser.parseExpression(configuration, arguments, classification);
+
+        String classificationName = expression.execute(configuration, arguments).toString();
+
+        return new IterationSpec(iterVarName, statusVarName, classificationName);
+    }
+
+    protected static class IterationSpec {
+
+        private final String iterVarName;
+        private final String statusVarName;
+        private final String classificationName;
+
+        public IterationSpec(final String iterVarName, final String statusVarName, final String classificationName) {
+            super();
+            Validate.notEmpty(iterVarName, "Iteration var name cannot be null or empty");
+            this.iterVarName = iterVarName;
+            this.statusVarName = statusVarName;
+            this.classificationName = classificationName;
+        }
+
+        public String getIterVarName() {
+            return this.iterVarName;
+        }
+
+        public String getStatusVarName() {
+            return this.statusVarName;
+        }
+
+        public Object getClassificationName() {
+            return this.classificationName;
+        }
+    }
+}

--- a/src/main/java/org/lastaflute/thymeleaf/processor/PropertyAttrProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/PropertyAttrProcessor.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.lastaflute.thymeleaf.processor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.thymeleaf.Arguments;
+import org.thymeleaf.Configuration;
+import org.thymeleaf.dom.Attribute;
+import org.thymeleaf.dom.Element;
+import org.thymeleaf.dom.NestableNode;
+import org.thymeleaf.processor.attr.AbstractAttributeModifierAttrProcessor;
+import org.thymeleaf.standard.StandardDialect;
+import org.thymeleaf.standard.expression.IStandardExpression;
+import org.thymeleaf.standard.expression.IStandardExpressionParser;
+import org.thymeleaf.standard.expression.StandardExpressions;
+import org.thymeleaf.standard.processor.attr.StandardEachAttrProcessor;
+
+/**
+ * Property Attribute Processor.
+ * <pre>
+ * Usage:
+ *   &lt;input type="text" la:property="memberName"/&gt;
+ *
+ * The result of processing this example will be as expected.
+ *   - MemberName with set to "Ariel"
+ *     &lt;input type="text" name="memberName" value="Ariel"/&gt;
+ *   - When MemberName have validation error.
+ *     &lt;input type="text" name="memberName" value="" class="validError"/&gt;
+ * </pre>
+ * @author schatten
+ */
+public class PropertyAttrProcessor extends AbstractAttributeModifierAttrProcessor {
+
+    private static final String EACH_PROPERTY_FORM_NAME = "'%s[' + ${%s.index} + '].%s'";
+    private static final String APPEND_ERROR_STYLE_CLASS = "${errors.hasMessageOf('%s')} ? 'validError'";
+    private static final String APPEND_ERROR_STYLE_CLASS_ATTRAPEND = "class=(${errors.hasMessageOf('%s')} ? ' validError')";
+    private static final String PROPERTY_ATTRIBUTE_NAME = "property";
+    private static final String EACH_ATTER_NAME = String.format("%s:%s", StandardDialect.PREFIX, StandardEachAttrProcessor.ATTR_NAME);
+
+    public PropertyAttrProcessor() {
+        super(PROPERTY_ATTRIBUTE_NAME);
+    }
+
+    @Override
+    public int getPrecedence() {
+        return 950;
+    }
+
+    @Override
+    protected Map<String, String> getModifiedAttributeValues(Arguments arguments, Element element, String attributeName) {
+        final Configuration configuration = arguments.getConfiguration();
+
+        // Obtain the attribute value
+        final String attributeValue = element.getAttributeValue(attributeName);
+
+        boolean hasThName = element.hasNormalizedAttribute(StandardDialect.PREFIX, "name");
+        boolean hasThText = element.hasNormalizedAttribute(StandardDialect.PREFIX, "text");
+        boolean hasThValue = element.hasNormalizedAttribute(StandardDialect.PREFIX, "value");
+        boolean hasThClassAppend = element.hasNormalizedAttribute(StandardDialect.PREFIX, "classappend");
+        boolean hasThAttrAppend = element.hasNormalizedAttribute(StandardDialect.PREFIX, "attrappend");
+
+        // Obtain the Thymeleaf Standard Expression parser
+        final IStandardExpressionParser parser = StandardExpressions.getExpressionParser(configuration);
+
+        // Parse the attribute value as a Thymeleaf Standard Expression
+        final IStandardExpression expression = parser.parseExpression(configuration, arguments, attributeValue);
+
+        String propertyName = expression.execute(configuration, arguments).toString();
+        final Map<String, String> values = new HashMap<String, String>();
+        String propertyFieldName = getPropertyFieldName(arguments, element, configuration, propertyName);
+        switch (element.getNormalizedName()) {
+            case "input":
+                if (!hasThName) {
+                    values.put("th:name", propertyFieldName);
+                }
+                if (!hasThValue) {
+                    String type = element.getAttributeValueFromNormalizedName("type");
+                    if (!("checkbox".equals(type) || "radio".equals(type))) {
+                        values.put("th:value", "${" + propertyName + "}");
+                    }
+                }
+                break;
+            case "select":
+                if (!hasThName) {
+                    values.put("th:name", propertyFieldName);
+                }
+                break;
+            case "textarea":
+                if (!hasThName) {
+                    values.put("th:name", propertyFieldName);
+                }
+                // not break.
+            default:
+                if (!hasThText) {
+                    values.put("th:text", "${" + propertyName + "}");
+                }
+                break;
+        }
+        if (!hasThClassAppend) {
+            values.put("th:classappend", String.format(APPEND_ERROR_STYLE_CLASS, propertyFieldName));
+        } else if (!hasThAttrAppend) {
+            values.put("th:attrappend", String.format(APPEND_ERROR_STYLE_CLASS_ATTRAPEND, propertyFieldName));
+        }
+
+        return values;
+    }
+
+    protected String getPropertyFieldName(Arguments arguments, Element element, final Configuration configuration, final String name) {
+        if (name.indexOf(".") > 0) {
+            String eachName = name.substring(0, name.indexOf(".")).trim();
+            String statusVariable = eachName + "Stat";
+            String eachAttr = getParentEachValue(element, eachName);
+            if (eachAttr == null) {
+                return name;
+            }
+            statusVariable = getProdStatusNameFromEachAttributeValue(eachAttr);
+            String expressionPropertyName = getExpressionPropertyName(eachAttr);
+            if (expressionPropertyName != null) {
+                if (expressionPropertyName.indexOf(".") > 0) {
+                    eachName = expressionPropertyName.substring(expressionPropertyName.lastIndexOf(".") + 1);
+                } else {
+                    eachName = expressionPropertyName;
+                }
+            }
+
+            String nextName = name.substring(name.indexOf(".") + 1);
+            return String.format(EACH_PROPERTY_FORM_NAME, eachName, statusVariable, nextName);
+        }
+        return name;
+    }
+
+    protected String getParentEachValue(Element element, String eachName) {
+        NestableNode parent = element.getParent();
+        if (parent instanceof Element) {
+            // Thymeleaf bug ?? NestableAttributeHolderNode.attributesLen is every access result zero.
+            //  if (((Element) parent).hasAttribute(EACH_ATTER_NAME)) {
+            //      String attVal = ((Element) parent).getAttributeValueFromNormalizedName(EACH_ATTER_NAME);
+            //      if (eachName.equals(getProdNameFromEachAttributeValue(attVal))) {
+            //          return attVal;
+            //      }
+            //  }
+            Attribute[] attributes = ((Element) parent).unsafeGetAttributes();
+            if (attributes != null) {
+                for (Attribute attribute : attributes) {
+                    if (attribute != null && EACH_ATTER_NAME.equals(attribute.getNormalizedName())) {
+                        if (eachName.equals(getProdNameFromEachAttributeValue(attribute.getValue()))) {
+                            return attribute.getValue();
+                        }
+                    }
+                }
+            }
+        }
+        if (parent instanceof Element && parent.hasParent()) {
+            return getParentEachValue((Element) parent, eachName);
+        }
+        return null;
+    }
+
+    private String getProdNameFromEachAttributeValue(String eachAttrVal) {
+        if (eachAttrVal == null) {
+            return null;
+        }
+        int separate = eachAttrVal.indexOf(":");
+        String prod = eachAttrVal.substring(0, separate);
+        int statusProd = prod.indexOf(",");
+        if (statusProd > 0) {
+            return prod.substring(0, statusProd).trim();
+        }
+        return prod.trim();
+    }
+
+    private String getProdStatusNameFromEachAttributeValue(String eachAttrVal) {
+        if (eachAttrVal == null) {
+            return null;
+        }
+        int separate = eachAttrVal.indexOf(":");
+        String prod = eachAttrVal.substring(0, separate);
+        int statusProd = prod.indexOf(",");
+        if (statusProd > 0) {
+            return prod.substring(statusProd).trim();
+        }
+        return prod.trim() + "Stat";
+    }
+
+    private String getExpressionPropertyName(String eachAttrVal) {
+        if (eachAttrVal == null) {
+            return null;
+        }
+        int separate = eachAttrVal.indexOf(":");
+        String expression = eachAttrVal.substring(separate + 1).trim();
+        Pattern pattern = Pattern.compile("\\$\\{([a-zA-Z_0-9.]+)\\}");
+        Matcher matcher = pattern.matcher(expression);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+    @Override
+    protected ModificationType getModificationType(Arguments arguments, Element element, String attributeName, String newAttributeName) {
+        return ModificationType.SUBSTITUTION;
+    }
+
+    @Override
+    protected boolean removeAttributeIfEmpty(Arguments arguments, Element element, String attributeName, String newAttributeName) {
+        return true;
+    }
+
+    @Override
+    protected boolean recomputeProcessorsAfterExecution(Arguments arguments, Element element, String attributeName) {
+        return true;
+    }
+
+}

--- a/src/main/java/org/lastaflute/thymeleaf/processor/PropertyAttrProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/PropertyAttrProcessor.java
@@ -43,21 +43,38 @@ import org.thymeleaf.standard.expression.StandardExpressions;
  */
 public class PropertyAttrProcessor extends AbstractAttributeModifierAttrProcessor {
 
+    // ===================================================================================
+    //                                                                          Definition
+    //                                                                          ==========
     private static final String PROPERTY_ATTRIBUTE_NAME = "property";
     private static final String APPEND_ERROR_STYLE_CLASS = "${errors.hasMessageOf('%s')} ? 'validError'";
     private static final String APPEND_ERROR_STYLE_CLASS_ATTRAPEND = "class=(${errors.hasMessageOf('%s')} ? ' validError')";
 
     protected static final String SELECT_PROPERTY_NAME = "la:selectPropertyName";
 
+    // ===================================================================================
+    //                                                                         Constructor
+    //                                                                         ===========
     public PropertyAttrProcessor() {
         super(PROPERTY_ATTRIBUTE_NAME);
     }
 
+    // ===================================================================================
+    //                                                                          Implements
+    //                                                                          ==========
+    /**
+     * {@inheritDoc}
+     * @see org.thymeleaf.processor.AbstractProcessor#getPrecedence()
+     */
     @Override
     public int getPrecedence() {
         return 950;
     }
 
+    /**
+     * {@inheritDoc}
+     * @see org.thymeleaf.processor.attr.AbstractAttributeModifierAttrProcessor#getModifiedAttributeValues(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String)
+     */
     @Override
     protected Map<String, String> getModifiedAttributeValues(Arguments arguments, Element element, String attributeName) {
         final Configuration configuration = arguments.getConfiguration();
@@ -133,16 +150,28 @@ public class PropertyAttrProcessor extends AbstractAttributeModifierAttrProcesso
         return name;
     }
 
+    /**
+     * {@inheritDoc}
+     * @see org.thymeleaf.processor.attr.AbstractAttributeModifierAttrProcessor#getModificationType(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String, java.lang.String)
+     */
     @Override
     protected ModificationType getModificationType(Arguments arguments, Element element, String attributeName, String newAttributeName) {
         return ModificationType.SUBSTITUTION;
     }
 
+    /**
+     * {@inheritDoc}
+     * @see org.thymeleaf.processor.attr.AbstractAttributeModifierAttrProcessor#removeAttributeIfEmpty(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String, java.lang.String)
+     */
     @Override
     protected boolean removeAttributeIfEmpty(Arguments arguments, Element element, String attributeName, String newAttributeName) {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     * @see org.thymeleaf.processor.attr.AbstractAttributeModifierAttrProcessor#recomputeProcessorsAfterExecution(org.thymeleaf.Arguments, org.thymeleaf.dom.Element, java.lang.String)
+     */
     @Override
     protected boolean recomputeProcessorsAfterExecution(Arguments arguments, Element element, String attributeName) {
         return true;

--- a/src/main/java/org/lastaflute/thymeleaf/processor/PropertyAttrProcessor.java
+++ b/src/main/java/org/lastaflute/thymeleaf/processor/PropertyAttrProcessor.java
@@ -48,11 +48,13 @@ import org.thymeleaf.standard.processor.attr.StandardEachAttrProcessor;
  */
 public class PropertyAttrProcessor extends AbstractAttributeModifierAttrProcessor {
 
+    private static final String PROPERTY_ATTRIBUTE_NAME = "property";
     private static final String EACH_PROPERTY_FORM_NAME = "'%s[' + ${%s.index} + '].%s'";
     private static final String APPEND_ERROR_STYLE_CLASS = "${errors.hasMessageOf('%s')} ? 'validError'";
     private static final String APPEND_ERROR_STYLE_CLASS_ATTRAPEND = "class=(${errors.hasMessageOf('%s')} ? ' validError')";
-    private static final String PROPERTY_ATTRIBUTE_NAME = "property";
     private static final String EACH_ATTER_NAME = String.format("%s:%s", StandardDialect.PREFIX, StandardEachAttrProcessor.ATTR_NAME);
+
+    protected static final String SELECT_PROPERTY_NAME = "la:selectPropertyName";
 
     public PropertyAttrProcessor() {
         super(PROPERTY_ATTRIBUTE_NAME);
@@ -101,6 +103,7 @@ public class PropertyAttrProcessor extends AbstractAttributeModifierAttrProcesso
                 if (!hasThName) {
                     values.put("th:name", propertyFieldName);
                 }
+                element.setNodeProperty(SELECT_PROPERTY_NAME, propertyName);
                 break;
             case "textarea":
                 if (!hasThName) {
@@ -166,9 +169,9 @@ public class PropertyAttrProcessor extends AbstractAttributeModifierAttrProcesso
                     }
                 }
             }
-        }
-        if (parent instanceof Element && parent.hasParent()) {
-            return getParentEachValue((Element) parent, eachName);
+            if (parent.hasParent()) {
+                return getParentEachValue((Element) parent, eachName);
+            }
         }
         return null;
     }

--- a/src/main/java/org/lastaflute/thymeleaf/wrapper/ActionMessagesWrapper.java
+++ b/src/main/java/org/lastaflute/thymeleaf/wrapper/ActionMessagesWrapper.java
@@ -46,7 +46,7 @@ public class ActionMessagesWrapper implements Serializable {
     }
 
     // ===================================================================================
-    //                                                                      Access Message
+    //                                                                      Convert Access
     //                                                                      ==============
     public List<ActionMessage> getAllMessages() {
         List<ActionMessage> list = new ArrayList<ActionMessage>();
@@ -61,7 +61,7 @@ public class ActionMessagesWrapper implements Serializable {
     }
 
     // ===================================================================================
-    //                                                                     Delegate method
+    //                                                                     Delegate Access
     //                                                                     ===============
     /**
      * @see org.lastaflute.web.ruts.message.ActionMessages#hasMessageOf(java.lang.String)

--- a/src/main/java/org/lastaflute/thymeleaf/wrapper/ActionMessagesWrapper.java
+++ b/src/main/java/org/lastaflute/thymeleaf/wrapper/ActionMessagesWrapper.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.lastaflute.thymeleaf.wrapper;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.lastaflute.web.ruts.message.ActionMessage;
+import org.lastaflute.web.ruts.message.ActionMessages;
+
+/**
+ * Read-only Action Messages Wrapper.
+ * @author schatten
+ */
+public class ActionMessagesWrapper implements Serializable {
+
+    // ===================================================================================
+    //                                                                          Definition
+    //                                                                          ==========
+    private static final long serialVersionUID = 1L;
+
+    // ===================================================================================
+    //                                                                           Attribute
+    //                                                                           =========
+    protected final ActionMessages messages;
+
+    // ===================================================================================
+    //                                                                         Constructor
+    //                                                                         ===========
+    public ActionMessagesWrapper(ActionMessages origin) {
+        this.messages = origin;
+    }
+
+    // ===================================================================================
+    //                                                                      Access Message
+    //                                                                      ==============
+    public List<ActionMessage> getAllMessages() {
+        List<ActionMessage> list = new ArrayList<ActionMessage>();
+        messages.accessByFlatIterator().forEachRemaining((message) -> list.add(message));
+        return list;
+    }
+
+    public List<ActionMessage> getMessages(String property) {
+        List<ActionMessage> list = new ArrayList<ActionMessage>();
+        messages.accessByIteratorOf(property).forEachRemaining((message) -> list.add(message));
+        return list;
+    }
+
+    // ===================================================================================
+    //                                                                     Delegate method
+    //                                                                     ===============
+    /**
+     * @see org.lastaflute.web.ruts.message.ActionMessages#hasMessageOf(java.lang.String)
+     */
+    public boolean hasMessageOf(String property) {
+        return messages.hasMessageOf(property);
+    }
+
+    /**
+     * @see org.lastaflute.web.ruts.message.ActionMessages#hasMessageOf(java.lang.String, java.lang.String)
+     */
+    public boolean hasMessageOf(String property, String key) {
+        return messages.hasMessageOf(property, key);
+    }
+
+    /**
+     * @see org.lastaflute.web.ruts.message.ActionMessages#isEmpty()
+     */
+    public boolean isEmpty() {
+        return messages.isEmpty();
+    }
+
+    /**
+     * @see org.lastaflute.web.ruts.message.ActionMessages#isAccessed()
+     */
+    public boolean isAccessed() {
+        return messages.isAccessed();
+    }
+
+    /**
+     * @see org.lastaflute.web.ruts.message.ActionMessages#size()
+     */
+    public int size() {
+        return messages.size();
+    }
+
+    /**
+     * @see org.lastaflute.web.ruts.message.ActionMessages#size(java.lang.String)
+     */
+    public int size(String property) {
+        return messages.size(property);
+    }
+
+}


### PR DESCRIPTION
Conversion from taglib for extend thymeleaf.
- Attribute Processors
  
  Prefix of attribute name is "la"
  - Property
    
    Write name, value and text.
    
    ``` html
    <input type="text" la:property="memberName"/>
    <textarea la:property="description"></textarea>
    ```
  - optionCls
    
    Write value and text.
    
    ``` html
    <select la:property="memberStatus">
    <option la:optionCls="'MemberStatus'"></option>
    </select>
    ```
  - foreach
    
    Help write name at list property.
    
    ``` html
    <div la:foreach="${friends}">
    <input type="text" la:property="memberName"/>
    </div>
    ```
- Expression Utility
  - handydate
    
    Utility of using HandyDate for date.
    
    ``` html
    <span th:text="${#handydate.format(member.birthdate)}">20XX-XX-XX</span>
    ```
  - cdef
    
    > This example is same to optionCls.
    
    ``` html
    <select name="memberStatus">
    <option th:each="def : ${#cdef.values('MemberStatus')}"
            th:value="${#cdef.code(def)}"
            th:text="${#cdef.alias(def)}"
            th:checked="${def} == ${memberStatus}"></option>
    </select>
    ```
- Wrapper for ActionMessages handling by list.
  
  ``` html
  <ul th:unless="${errors.empty}" style="display: none" th:style="'color : red;'">
  <li th:each="error : ${errors.allMessages}"
      th:text="${error.isResource()} ? #{${error.key}(${error.values})} : ${error.key}"></li>
  </ul>
  ```
